### PR TITLE
prop에 type 주기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,3 +1,4 @@
+import TodoItem from './components/TodoItem';
 import { dummyData } from './data/todos';
 
 function App() {
@@ -7,9 +8,7 @@ function App() {
       <div className='max-w-lg mx-auto'>
         <div className='space-y-2'>
           {dummyData.map((todo) => (
-            <p key={todo.id} className='text-lg'>
-              {todo.title}
-            </p>
+            <TodoItem todo={todo} />
           ))}
         </div>
       </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,9 +3,9 @@ import { dummyData } from './data/todos';
 
 function App() {
   return (
-    <main className='py-10 h-screen'>
+    <main className='py-10 h-screen space-y-5'>
       <h1 className='font-bold text-3xl text-center'>Your Todos</h1>
-      <div className='max-w-lg mx-auto'>
+      <div className='max-w-lg mx-auto bg-slate-100 rounded-md p-5'>
         <div className='space-y-2'>
           {dummyData.map((todo) => (
             <TodoItem todo={todo} />

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,0 +1,11 @@
+import { Todo } from '../types/todo';
+
+interface TodoItemProps {
+  todo: Todo;
+}
+
+const TodoItem = ({ todo }: TodoItemProps) => {
+  return <div>{todo.title}</div>;
+};
+
+export default TodoItem;

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -5,7 +5,16 @@ interface TodoItemProps {
 }
 
 const TodoItem = ({ todo }: TodoItemProps) => {
-  return <div>{todo.title}</div>;
+  return (
+    <div>
+      <label className='flex items-center gap-2 border rounded-md p-2 border-gray-400 bg-white hover:bg-slate-50'>
+        <input type='checkbox' className='scale-125' />
+        <span className={todo.completed ? 'line-through text-gray-400' : ''}>
+          {todo.title}
+        </span>
+      </label>
+    </div>
+  );
 };
 
 export default TodoItem;


### PR DESCRIPTION
# React & TypeScript

- 원래 기존엔 더미데이터에만 Todo라는 타입을 지정해주었음

## props에 type 주기

```tsx
import { Todo } from '../types/todo';

interface TodoItemProps {
  todo: Todo;
}

const TodoItem = ({ todo }: TodoItemProps) => {
  return (
    <div>
      <label className='flex items-center gap-2 border rounded-md p-2 border-gray-400 bg-white hover:bg-slate-50'>
        <input type='checkbox' className='scale-125' />
        <span className={todo.completed ? 'line-through text-gray-400' : ''}>
          {todo.title}
        </span>
      </label>
    </div>
  );
};

export default TodoItem;
```

- `TodoItem` 컴포넌트는 `props`로 `todo` 객체를 받음
    - 여기서 객체는 이미 정의된 `Todo` 타입을 따름
- `Todo`라는 타입은 `../types/todo` 파일에 정의되어 있고, `TodoItem` 컴포넌트에서 `Todo` 타입을 `props`로 재사용하는 방식

### 장점

- 타입 일관성을 유지
- 여러 곳에서 동일한 데이터 구조를 사용중일 때 중복된 타입 정의를 피할 . 수있음
    - dummyData와 TodoItem 컴포넌트가 동일한 Todo 타입을 공유

### 이렇게 변경해볼 수 있을까?

```tsx
import { Todo } from '../types/todo';

// interface TodoItemProps {
//   todo: Todo;
// }

const TodoItem = ({ todo }: Todo) => {
  return <div>{todo.title}</div>;
};

export default TodoItem;
```

- 에러가 발생 **`'Todo' 형식에 'todo' 속성이 없습니다.ts(2339)`**

### 원인

```tsx
const TodoItem = ({ todo }: Todo) => { ... }
```

- 해당 코드에서 `{ todo }: Todo`는 props에 todo라는 속성이 있는 것처럼 해석된다고 한다.
내가 해야 하는건 props 객체 안에 todo라는 속성이 있고, 해당 속성의 타입이 Todo라고 정의해야 한다.
    - 어…? props안의 todo라는 속성이 Todo타입이니까 올바르게 동작해야 하는거 아님…? 구조분해 할당 해줬잖아…?

### 문제는 구조분해 할당이 아니야 바보야!

- **타입스크립트에서 타입을 지정하는 방식**

```tsx
const TodoItem = ({ todo }: Todo) => { ... }
```

- 이 코드에서 **`Todo` 타입**은 `todo`라는 객체에 대한 타입 정의가 아니라, **`props` 전체**에 대한 타입 정의로 해석됨
    - `({ todo }: Todo)`라고 하면, **`props` 전체가 `Todo` 타입**이라는 뜻으로 해석되는데, 실제로는 `props` 객체 안에 `todo`라는 속성이 들어있고, 그 `todo`의 타입이 `Todo`여야 함
    - 즉, **props 자체가 `Todo` 타입이 되는 것**이 아니라, **`props` 안에 있는 `todo` 속성이 `Todo` 타입이 되는 것**을 나는 원함!

```tsx
export interface Todo {
  id: number;
  title: string;
  completed: boolean;
}
```

- 그러니까 내 잘못된 코드에 의해서, props 전체가 위의 Todo 타입으로 인식되어서, 타입스크립트는 props가 `{ id, title, completed }` 속성을 모두 가져야 한다고 생각해버림
- 하지만 실제로 **`props` 객체는 `todo`라는 속성을 포함하고 있고**, 그 속성 안에 `id`, `title`, `completed`가 있는 것
    - 올바르게 사용하려면, **`props` 객체에 `todo`라는 속성이 있고**, 그 속성의 타입이 `Todo` 여야 함!

### 정리

- `({ todo }: Todo)`는 props 전체가 `Todo` 타입으로 해석되는 문제를 만들어버림.
- 실제로는 **`props` 객체의 `todo` 속성만 `Todo` 타입**이기 때문에, 타입 정의를 따로 해줘야 함.
- 그래서 `TodoItemProps`라는 별도의 인터페이스를 만들어서, `props` 안의 `todo` 속성의 타입을 `Todo`로 지정하는 방식이 올바른 것!.