### PR TITLE
글 삭제기능 구현과 type의 props drilling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import TodoItem from './components/TodoItem';
 import { dummyData } from './data/todos';
 import AddTodoForm from './components/AddTodoForm';
+import TodoList from './components/TodoList';
 
 function App() {
   const [todos, setTodos] = useState(dummyData);
@@ -23,20 +23,20 @@ function App() {
     ]);
   }
 
+  function deleteTodo(id: number) {
+    setTodos((prevTodos) => prevTodos.filter((todo) => todo.id !== id));
+  }
+
   return (
-    <main className='py-10 h-screen space-y-5'>
+    <main className='py-10 h-screen space-y-5 overflow-y-auto'>
       <h1 className='font-bold text-3xl text-center'>Your Todos</h1>
       <div className='max-w-lg mx-auto bg-slate-100 rounded-md p-5 space-y-6'>
         <AddTodoForm onSubmit={addTodo} />
-        <div className='space-y-2'>
-          {todos.map((todo) => (
-            <TodoItem
-              todo={todo}
-              key={todo.id}
-              onCompletedChange={setTodoCompleted}
-            />
-          ))}
-        </div>
+        <TodoList
+          todos={todos}
+          onCompletedChange={setTodoCompleted}
+          onDelete={deleteTodo}
+        />
       </div>
     </main>
   );

--- a/src/components/TodoItem.tsx
+++ b/src/components/TodoItem.tsx
@@ -1,14 +1,16 @@
 import { Todo } from '../types/todo';
+import { Trash2 } from 'lucide-react';
 
 interface TodoItemProps {
   todo: Todo;
   onCompletedChange: (id: number, completed: boolean) => void;
+  onDelete: (id: number) => void;
 }
 
-const TodoItem = ({ todo, onCompletedChange }: TodoItemProps) => {
+const TodoItem = ({ todo, onCompletedChange, onDelete }: TodoItemProps) => {
   return (
-    <div>
-      <label className='flex items-center gap-2 border rounded-md p-2 border-gray-400 bg-white hover:bg-slate-50'>
+    <div className='flex items-center gap-1'>
+      <label className='flex items-center gap-2 border rounded-md p-2 border-gray-400 bg-white hover:bg-slate-50 grow'>
         <input
           type='checkbox'
           checked={todo.completed}
@@ -19,6 +21,9 @@ const TodoItem = ({ todo, onCompletedChange }: TodoItemProps) => {
           {todo.title}
         </span>
       </label>
+      <button className='p-2' onClick={() => onDelete(todo.id)}>
+        <Trash2 size={20} className='text-gray-500' />
+      </button>
     </div>
   );
 };

--- a/src/components/TodoList.tsx
+++ b/src/components/TodoList.tsx
@@ -1,0 +1,39 @@
+import { Todo } from '../types/todo';
+import TodoItem from './TodoItem';
+
+interface TodoListProps {
+  todos: Todo[];
+  onCompletedChange: (id: number, completed: boolean) => void;
+  onDelete: (id: number) => void;
+}
+
+const TodoList = ({ todos, onCompletedChange, onDelete }: TodoListProps) => {
+  const todosSorted = todos.sort((a, b) => {
+    if (a.completed === b.completed) {
+      return b.id - a.id;
+    }
+    return a.completed ? 1 : -1;
+  });
+
+  return (
+    <>
+      <div className='space-y-2'>
+        {todosSorted.map((todo) => (
+          <TodoItem
+            todo={todo}
+            key={todo.id}
+            onCompletedChange={onCompletedChange}
+            onDelete={onDelete}
+          />
+        ))}
+      </div>
+      {todos.length === 0 && (
+        <p className='text-center text-sm text-gray-500'>
+          No todos yet. Add a new one above.
+        </p>
+      )}
+    </>
+  );
+};
+
+export default TodoList;


### PR DESCRIPTION
# React & TypeScript

## Props drilling

- App.tsx

```tsx
function deleteTodo(id: number) {
  setTodos((prevTodos) => prevTodos.filter((todo) => todo.id !== id));
}

<TodoList
  todos={todos}
  onCompletedChange={setTodoCompleted}
  onDelete={deleteTodo}
/>
```

- TodoList.tsx

```tsx
{todosSorted.map((todo) => (
  <TodoItem
    todo={todo}
    key={todo.id}
    onCompletedChange={onCompletedChange}
    onDelete={onDelete}
  />
))}
```

- TodoItem.tsx

```tsx
<button className='p-2' onClick={() => onDelete(todo.id)}>
  <Trash2 size={20} className='text-gray-500' />
</button>
```

### 상태를 내리거나 올려줄 때에도 props에 type을 정해줘야 한다.

- App.tsx

```tsx
function deleteTodo(id: number) {
  setTodos((prevTodos) => prevTodos.filter((todo) => todo.id !== id));
}
```

- TodoList.tsx

```tsx
interface TodoListProps {
  todos: Todo[];
  onCompletedChange: (id: number, completed: boolean) => void;
  onDelete: (id: number) => void;
}
```

- TodoItem.tsx

```tsx
interface TodoItemProps {
  todo: Todo;
  onCompletedChange: (id: number, completed: boolean) => void;
  onDelete: (id: number) => void;
}
```

- 현재 TodoList에서는 onDelete를 딱히 사용하고 있지 않다. 그저 TodoItem으로 거쳐서 보내주는 용도
- 하지만, 전역상태 라이브러리를 사용하지 않으므로, props로 계속 내려주는 방식을 사용해야 함
    - 이 과정에서 각 컴포넌트는 필요 함수, 상태를 props로 받아 처리ㅎ함
    - 직접 사용되지 않더라도 props로 전달해주고, React + TS 에서는 props 또한 타입을 지정해주어야 함

### 리액트에서 props에도 타입을 지정하는 이유

- 컴파일 타입에 오류 발견
    - TS는 코드를 컴파일 하는 동안에 props에 전달된 값이 올바른 타입인지 검사해줌
    - 이 때, 타입을 명시하지 않으면 잘못된 데이터 타입이 Props로 전달될 수 있는데, 이 경우 컴파일 타임에 발견되지 않고, 런타임에서 오류가 발생할 수 있음.

**결국  더 안전하고 예측 가능한 코드를 작성하기 위함!**

## filter를 통한 삭제

### 로직 설명

```tsx
function deleteTodo(id: number) {
  setTodos((prevTodos) => prevTodos.filter((todo) => todo.id !== id));
}
```

- `deleteTodo` 함수는 `id` 값을 매개변수로 받음. 이 `id`는 삭제하려는 특정 할 일의 ID
- `setTodos` 함수는 `todos` 상태를 업데이트하기 위해 사용됨. `filter` 메서드를 통해 기존 `todos` 배열을 새로운 배열로 변환하여 상태를 업데이트함.
- `prevTodos`는 현재 상태의 `todos` 배열. `filter`는 이 배열을 순회하면서 각 `todo` 객체의 `id`를 확인
- `todo.id !== id` 조건에서, 현재 순회 중인 `todo` 객체의 `id`가 삭제하고자 하는 `id`와 같지 않은 경우에만 해당 `todo`를 새로운 배열에 포함함. 즉, **삭제하려는 `id`와 동일한 `todo`는 걸러내어 포함하지 않음**
- 결과적으로, `id`가 일치하지 않는 `todo`들만 포함된 새 배열이 반환되어 `todos` 상태를 업데이트.

## sort를 통한 정렬

### 로직 설명

```tsx
const todosSorted = todos.sort((a, b) => {
  if (a.completed === b.completed) {
    return b.id - a.id;
  }
  return a.completed ? 1 : -1;
});
```

- 기본적으로 sort는 사전 순, 오름차순으로 정렬하나, 커스텀 정렬을 위해 콜백 함수 (a, b)를 사용
    - 각각 todos 배열의 항목
- **동일한 `completed` 상태일 경우**, 즉 두 항목이 둘 다 완료되었거나 둘 다 완료되지 않은 상태라면, `id`를 기준으로 내림차순으로 정렬. (`b.id - a.id`는 ID가 큰 항목이 앞에 오도록 정렬)
- `a.completed`가 `true`라면, 즉 첫 번째 항목(`a`)이 완료된 할 일이면 `1`을 반환합니다. 이는 첫 번째 항목을 뒤로 보내라는 의미
- `a.completed`가 `false`라면 `-1`을 반환합니다. 이는 첫 번째 항목을 앞으로 보내라는 의미
- **완료 여부 비교**: `completed` 상태가 다르면, 완료된 할 일(`true`)은 아래로, 완료되지 않은 할 일(`false`)은 위로 정렬
- **ID 순서 정렬**: `completed` 상태가 같다면, ID를 기준으로 내림차순으로 정렬되어 ID가 큰 항목이 먼저 나오게 됨